### PR TITLE
Remove deprecated version variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   slave:
     build:


### PR DESCRIPTION
Fix the following warning:
```
WARN[0000] /home/cloud/jenkins-slave-deploy-docker/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```